### PR TITLE
Windows paths are separated with a backslash

### DIFF
--- a/src/components/React.js
+++ b/src/components/React.js
@@ -177,6 +177,7 @@ class React {
         // If the loader is not the css-loader, we can safely skip it
         if (
             rule.loader.indexOf('/css-loader/') === -1 &&
+            rule.loader.indexOf('\\css-loader\\') === -1 &&
             rule.loader !== 'css-loader' &&
             rule !== 'css-loader'
         ) {


### PR DESCRIPTION
Most probable cause why the Windows tests are failing